### PR TITLE
Update references.py

### DIFF
--- a/opencve/checks/references.py
+++ b/opencve/checks/references.py
@@ -38,7 +38,7 @@ class References(BaseCheck):
         modified_urls = list(
             set(
                 [
-                    r.split("'")[1]
+                    r.split("'][")[0].split("['")[1]
                     for r in list(diff.get("values_changed", {}).keys())
                     + list(diff.get("iterable_item_added", {}).keys())
                 ]


### PR DESCRIPTION
When processing modified references urls containing single quotes (line 41), the current extraction method will truncate the url, resulting in a "KeyError" (line 48) when using a dictionary to obtain data subsequently. For example, the reference link of CVE-2022-1980: [https://github.com/Xor-Gerke/webray.com.cn/blob/main/cve/Product%20Show%20Room%20Site/'Telephone'%20Stored%20Cross -Site%20Scripting(XSS).md], I adjusted the extraction method and tested it in practice.